### PR TITLE
Add a feature to make RGB voltage configurable

### DIFF
--- a/docs/anduril-manual.md
+++ b/docs/anduril-manual.md
@@ -453,11 +453,22 @@ The voltage config menu has these settings:
      `12C`: +0.25V  
      `13C`: +0.30V
 
-  2. Post-off voltage display timeout.  (only on lights with RGB aux)  
+  2. Post-off voltage display timeout.  (only on lights with RGB aux)
      This setting determines how many seconds the RGB aux LEDs
      display the voltage color after the torch goes to sleep.  Click
      once per desired second, or zero times to turn this function
      off.
+
+  3. RGB voltage while on high threshold. On lights where the battery
+     voltage is displayed using RGB aux while the light is on, sets
+     the ramp level at which the aux will switch to high brightness.
+     If set to 151, this effectively forces the voltage to only ever
+     be displayed using low brightness, or if set to 0, to only ever
+     use high brightness.
+
+  4. RGB voltage while on minimum level. Below this level, voltage will
+     not be displayed using the RGB aux at all. Setting this to 151+
+     effectively disables the entire feature.
 
 ### Temperature check:
 

--- a/fsm/ramping.c
+++ b/fsm/ramping.c
@@ -41,9 +41,16 @@ inline void set_level_aux_leds(uint8_t level) {
 #include "anduril/aux-leds.h"  // for rgb_led_voltage_readout()
 inline void set_level_aux_rgb_leds(uint8_t level) {
     if (! go_to_standby) {
+        #ifdef USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS
+        if ((level > 0) && (actual_level > cfg.use_aux_rgb_leds_while_on_min_level)){
+            rgb_led_voltage_readout(level > cfg.use_aux_rgb_leds_while_on);
+        }
+        #else
         if (level > 0) {
             rgb_led_voltage_readout(level > USE_AUX_RGB_LEDS_WHILE_ON);
-        } else {
+        }
+        #endif
+        else {
             rgb_led_set(0);
         }
         // some drivers can be wired with RGB or single color to button

--- a/hw/hank/emisar-d1v2/7135-fet/anduril.h
+++ b/hw/hank/emisar-d1v2/7135-fet/anduril.h
@@ -15,6 +15,7 @@
 //  so it's unlikely that anyone needs this, but it doesn't hurt anything)
 #define USE_AUX_RGB_LEDS
 #define USE_AUX_RGB_LEDS_WHILE_ON  25
+#define USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 // safe limit ~50% power

--- a/hw/hank/emisar-d1v2/linear-fet/anduril.h
+++ b/hw/hank/emisar-d1v2/linear-fet/anduril.h
@@ -13,6 +13,7 @@
 // the aux LEDs are in the button, so use them while main LEDs are on
 #define USE_AUX_RGB_LEDS
 #define USE_AUX_RGB_LEDS_WHILE_ON  25
+#define USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 // safe limit: max regulated power

--- a/hw/hank/emisar-d1v2/nofet/anduril.h
+++ b/hw/hank/emisar-d1v2/nofet/anduril.h
@@ -13,6 +13,7 @@
 // the aux LEDs are in the button, so use them while main LEDs are on
 #define USE_AUX_RGB_LEDS
 #define USE_AUX_RGB_LEDS_WHILE_ON  25
+#define USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 // safe limit: same as regular ramp

--- a/hw/hank/emisar-d4k-3ch/anduril.h
+++ b/hw/hank/emisar-d4k-3ch/anduril.h
@@ -12,6 +12,7 @@
 // turn on the aux LEDs while main LEDs are on
 // (in case there's a RGB button)
 #define USE_AUX_RGB_LEDS_WHILE_ON  40
+#define USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 // channel modes...

--- a/hw/hank/noctigon-k1/anduril.h
+++ b/hw/hank/noctigon-k1/anduril.h
@@ -14,6 +14,7 @@
 // this light has three aux LED channels: R, G, B
 #define USE_AUX_RGB_LEDS
 #define USE_AUX_RGB_LEDS_WHILE_ON  5
+#define USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 

--- a/hw/hank/noctigon-k1/boost/anduril.h
+++ b/hw/hank/noctigon-k1/boost/anduril.h
@@ -17,6 +17,7 @@
 // this light has three aux LED channels: R, G, B
 #define USE_AUX_RGB_LEDS
 #define USE_AUX_RGB_LEDS_WHILE_ON  25
+#define USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 #if 0  // old, 10-bit PWM method

--- a/hw/hank/noctigon-k1/sbt90/anduril.h
+++ b/hw/hank/noctigon-k1/sbt90/anduril.h
@@ -14,6 +14,7 @@
 // this light has three aux LED channels: R, G, B
 #define USE_AUX_RGB_LEDS
 #define USE_AUX_RGB_LEDS_WHILE_ON  10
+#define USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 

--- a/hw/wurkkos/fc13/anduril.h
+++ b/hw/wurkkos/fc13/anduril.h
@@ -10,5 +10,6 @@
 
 // turn on the aux LEDs while main LEDs are on
 #define USE_AUX_RGB_LEDS_WHILE_ON  20
+#define USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS
 #define USE_INDICATOR_LED_WHILE_RAMPING
 

--- a/hw/wurkkos/ts11/anduril.h
+++ b/hw/wurkkos/ts11/anduril.h
@@ -12,5 +12,6 @@
 // (but not until the main LEDs are bright enough to overpower the aux)
 // (setting this lower makes an annoying effect on some levels)
 #define USE_AUX_RGB_LEDS_WHILE_ON  50
+#define USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS
 #define USE_INDICATOR_LED_WHILE_RAMPING
 

--- a/ui/anduril/anduril.c
+++ b/ui/anduril/anduril.c
@@ -278,9 +278,13 @@ void loop() {
     StatePtr state = current_state;
 
     #ifdef USE_AUX_RGB_LEDS_WHILE_ON
-    // display battery charge on RGB button during use
-    if (state == steady_state)
-        rgb_led_voltage_readout(actual_level > USE_AUX_RGB_LEDS_WHILE_ON);
+        // display battery charge on RGB button during use
+      #ifdef USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS
+        if ((state == steady_state) && (actual_level > cfg.use_aux_rgb_leds_while_on_min_level)) // only show voltage if we are above the configured minimum ramp level
+      #else
+        if (state == steady_state)
+      #endif
+          rgb_led_voltage_readout(actual_level > USE_AUX_RGB_LEDS_WHILE_ON);
     #endif
 
     if (0) {}  // placeholder

--- a/ui/anduril/battcheck-mode.c
+++ b/ui/anduril/battcheck-mode.c
@@ -61,21 +61,23 @@ uint8_t battcheck_state(Event event, uint16_t arg) {
 // ...
 // 13 = add 0.30V
 void voltage_config_save(uint8_t step, uint8_t value) {
-    #ifdef USE_POST_OFF_VOLTAGE
-        if (2 == step) cfg.post_off_voltage = value;
-        else
+    #if defined(USE_AUX_RGB_LEDS_WHILE_ON) && defined(USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS)
+      if (use_aux_rgb_leds_while_on_config_step == step) cfg.use_aux_rgb_leds_while_on = value;
+      else if (use_aux_rgb_leds_while_on_min_level_step == step) cfg.use_aux_rgb_leds_while_on_min_level = value;
+      else
     #endif
-    if (value) cfg.voltage_correction = value;
+    #ifdef USE_POST_OFF_VOLTAGE
+      if (post_off_voltage_config_step == step) cfg.post_off_voltage = value;
+      else
+    #endif
+    #ifdef USE_VOLTAGE_CORRECTION
+      if (value) cfg.voltage_correction = value;
+    #endif
 }
 
 uint8_t voltage_config_state(Event event, uint16_t arg) {
-    #ifdef USE_POST_OFF_VOLTAGE
-        #define VOLTAGE_CONFIG_STEPS  2
-    #else
-        #define VOLTAGE_CONFIG_STEPS  1
-    #endif
     return config_state_base(event, arg,
-                             VOLTAGE_CONFIG_STEPS,
+                             (voltage_config_num_steps - 1),
                              voltage_config_save);
 }
 #endif  // #ifdef USE_VOLTAGE_CORRECTION

--- a/ui/anduril/battcheck-mode.h
+++ b/ui/anduril/battcheck-mode.h
@@ -10,3 +10,18 @@ void voltage_config_save(uint8_t step, uint8_t value);
 uint8_t voltage_config_state(Event event, uint16_t arg);
 #endif
 
+typedef enum {
+    voltage_cfg_zero = 0,
+    #ifdef USE_VOLTAGE_CORRECTION
+      voltage_correction_config_step,
+    #endif
+    #ifdef USE_POST_OFF_VOLTAGE
+      post_off_voltage_config_step,
+    #endif
+    #if defined(USE_AUX_RGB_LEDS_WHILE_ON) && defined(USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS)
+      use_aux_rgb_leds_while_on_config_step,
+      use_aux_rgb_leds_while_on_min_level_step,
+    #endif
+    voltage_config_num_steps
+} voltage_config_steps_e;
+

--- a/ui/anduril/load-save-config-fsm.h
+++ b/ui/anduril/load-save-config-fsm.h
@@ -97,6 +97,10 @@ typedef struct Config {
         uint8_t therm_ceil;
         int8_t therm_cal_offset;
     #endif
+    #if defined(USE_AUX_RGB_LEDS_WHILE_ON) && defined(USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS)
+        uint8_t use_aux_rgb_leds_while_on;
+        uint8_t use_aux_rgb_leds_while_on_min_level;
+    #endif
 
     ///// aux LEDs
     #ifdef USE_INDICATOR_LED

--- a/ui/anduril/load-save-config.h
+++ b/ui/anduril/load-save-config.h
@@ -169,5 +169,20 @@ Config cfg = {
         .jump_start_level = DEFAULT_JUMP_START_LEVEL,
     #endif
 
+    #if defined(USE_AUX_RGB_LEDS_WHILE_ON) && defined(USE_CONFIGURABLE_RGB_VOLTAGE_LEVELS)
+        // config for RGB voltage. We need to check these here rather than setting defaults in `config-default.h` as we only know *after* defaults are loaded if `USE_AUX_RGB_LEDS_WHILE_ON` is set or unset (in `CFG_H`).
+        #if (USE_AUX_RGB_LEDS_WHILE_ON + 0) // if USE_AUX_RGB_LEDS_WHILE_ON is an int, passes. If blank (undefined or defined with no value), evaluates to `(+0)` which evaluates to false.
+        .use_aux_rgb_leds_while_on = USE_AUX_RGB_LEDS_WHILE_ON,
+        #else
+        #warning "USE_AUX_RGB_LEDS_WHILE_ON defined but has no value. Setting minimum threshold to default of 25"
+        .use_aux_rgb_leds_while_on = 25,
+        #endif
+        #ifdef USE_AUX_RGB_LEDS_WHILE_ON_INITIAL_MINIMUM_LEVEL
+        .use_aux_rgb_leds_while_on_min_level = USE_AUX_RGB_LEDS_WHILE_ON_INITIAL_MINIMUM_LEVEL,
+        #else
+        .use_aux_rgb_leds_while_on_min_level = 15, // default
+        #endif
+    #endif
+
 };
 


### PR DESCRIPTION
Adds two entries to the battery voltage settings menu, the first isathreshold for switching aux to high, and the second sets a minimum level for it to be displayed, also effectively allowing the feature to be entirely disabled if not wanted.